### PR TITLE
Include documentation for how to upload files that are not PDFs

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -86,7 +86,7 @@ Uploading a document that is not a PDF
 -------------------------------------------------
 
 You can upload a document whose file extension is one of the seventy supported filetypes by including the original_extension parameter 
- (See https://www.muckrock.com/news/archives/2020/nov/10/release-notes-beta-document-types/ for supported filetypes)
+ (See https://www.documentcloud.org/help/api#supported-file-types for supported filetypes)
  Example: Uploading a JPG file that is stored in your home directory. 
 
     >>> obj = self.client.documents.upload("~/test.jpg", original_extension='jpg')

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -82,6 +82,16 @@ You can also provide URLs that link to PDFs, if that's the kind of thing you're 
 
     >>> client.documents.upload("http://ord.legistar.com/Chicago/attachments/e3a0cbcb-044d-4ec3-9848-23c5692b1943.pdf")
 
+Uploading a document that is not a PDF
+-------------------------------------------------
+
+You can upload a document whose file extension is one of the seventy supported filetypes by including the original_extension parameter 
+ (See https://www.muckrock.com/news/archives/2020/nov/10/release-notes-beta-document-types/ for supported filetypes)
+ Example: Uploading a JPG file that is stored in your home directory. 
+
+    >>> obj = self.client.documents.upload("~/test.jpg", original_extension='jpg')
+
+
 Interacting with a newly uploaded public document
 -------------------------------------------------
 


### PR DESCRIPTION
Currently there is no documentation that includes an example where a user can upload a document that is not a PDF, even though the API has that functionality.