### PR TITLE
Run pylint & black on PRs and commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,3 +31,23 @@ jobs:
         run: |
           make test
         working-directory: .
+
+  pylint-and-black:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Install pylint and black
+        run: |
+          pip install pylint black
+
+      - name: Run pylint and black
+        run: |
+          pylint ./documentcloud
+          black  ./documentcloud

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-
+          
+      - name: Install dependencies for imports
+        run: |
+           pip install python-dateutil requests urllib3 fastjsonschema ratelimit listcrunch
+           
       - name: Install pylint and black
         run: |
           pip install pylint black

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
           
       - name: Install dependencies for imports
         run: |
-           pip install python-dateutil requests urllib3 fastjsonschema ratelimit listcrunch
+           pip install python-dateutil requests urllib3 fastjsonschema ratelimit listcrunch pyyaml
            
       - name: Install pylint and black
         run: |


### PR DESCRIPTION
This runs on the ./documentcloud directory for now. 
Tests have some of  their own pylint issues:

s@pop-os:~/python-documentcloud$ pylint ./tests
************* Module tests.test_documents
tests/test_documents.py:78:12: C0209: Formatting a regular string which could be an f-string (consider-using-f-string)
tests/test_documents.py:161:44: C0209: Formatting a regular string which could be an f-string (consider-using-f-string)
tests/test_documents.py:179:14: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
************* Module tests.conftest
tests/conftest.py:145:16: C0209: Formatting a regular string which could be an f-string (consider-using-f-string)

I'm opening an issue for that, and then will include that directory in the pylint & black checks. 